### PR TITLE
Added logging capability for graph requests

### DIFF
--- a/ApprovalBot/PrivateSettings.example.config
+++ b/ApprovalBot/PrivateSettings.example.config
@@ -2,7 +2,11 @@
   <!-- update these with your Microsoft App Id and your Microsoft App Password-->
   <add key="MicrosoftAppId" value="YOUR APP ID HERE" />
   <add key="MicrosoftAppPassword" value="YOUR APP PASSWORD HERE" />
+
   <add key="AppRootUrl" value="http://localhost:3979" />
+
+  <!-- Only set this if running the sample locally. This will be used -->
+  <!-- to set the action URLs of the actionable message -->
   <add key="NgrokRootUrl" value="" />
 
   <!-- Cosmos DB information -->
@@ -12,4 +16,7 @@
   <!-- Actionable Email Dashboard settings -->
   <add key="OrignatorId" value="" />
   <add key="SenderEmail" value="" />
+
+  <!-- Enable graph request logging (performance hit) -->
+  <add key="LogGraphRequests" value="true" />
 </appSettings>


### PR DESCRIPTION
Can turn on logging in PrivateSettings.config. Requests and responses will be stored in the database, can be correlated with requestId.